### PR TITLE
chore: removed travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-cache: yarn
-node_js:
-  - "14"
-  - "12"
-  - "8"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-
-[![Build Status](https://travis-ci.org/karak/diff-match-patch-line-and-word.svg?branch=master)](https://travis-ci.org/karak/diff-match-patch-line-and-word)
-
 Diff Patch Merge Line and Word
 ====
 


### PR DESCRIPTION
Removed travis-ci settings because we are migrating to GitHub Actions.